### PR TITLE
Item names must be non-empty

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -124,7 +124,7 @@ class AddItemDialog extends HookWidget {
                         ? Colors.orange
                         : Theme.of(context).primaryColor),
                 onPressed: () {
-                  if(item.name.isEmpty) {
+                  if(textController.text.isEmpty) {
                     ScaffoldMessenger.of(context).showSnackBar(
                       SnackBar(
                         backgroundColor: Theme.of(context).primaryColor,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -124,6 +124,16 @@ class AddItemDialog extends HookWidget {
                         ? Colors.orange
                         : Theme.of(context).primaryColor),
                 onPressed: () {
+                  if(item.name.isEmpty) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(
+                        backgroundColor: Theme.of(context).primaryColor,
+                        duration: const Duration(seconds: 2),
+                        content: const Text('Items must have a name.')
+                      )
+                    );
+                    return;
+                  }
                   isUpdating
                       ? context
                           .read(itemListControllerProvider.notifier)


### PR DESCRIPTION
I figured it would be reasonable to check for empty names before allowing the user to add/upgrade an item in the list.